### PR TITLE
Manual zero calibration

### DIFF
--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -207,11 +207,17 @@ uint32_t AGS02MA::readUGM3()
 
 bool AGS02MA::zeroCalibration()
 {
+  return manualZeroCalibration(0);
+}
+
+
+bool AGS02MA::manualZeroCalibration(uint16_t value)
+{
   _buffer[0] = 0x00;
   _buffer[1] = 0x0C;
-  _buffer[2] = 0xFF;
-  _buffer[3] = 0xF3;
-  _buffer[4] = 0xFC;
+  _buffer[2] = (uint8_t) (value >> 8);
+  _buffer[3] = (uint8_t) value;
+  _buffer[4] = _CRC8(_buffer, 4);
   return _writeRegister(AGS02MA_CALIBRATION);
 }
 

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -301,6 +301,15 @@ bool AGS02MA::_writeRegister(uint8_t reg)
   return (_error == 0);
 }
 
+uint16_t AGS02MA::_dataMSB(uint8_t * buf)
+{
+  return (buf[0] << 8) + buf[1];
+}
+
+uint16_t AGS02MA::_dataLSB(uint8_t * buf)
+{
+  return (buf[2] << 8) + buf[3];
+}
 
 uint8_t AGS02MA::_CRC8(uint8_t * buf, uint8_t size)
 {

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -1,8 +1,8 @@
 //
 //    FILE: AGS02MA.cpp
-//  AUTHOR: Rob Tillaart, Viktor Balint
+//  AUTHOR: Rob Tillaart, Viktor Balint, Beanow
 //    DATE: 2021-08-12
-// VERSION: 0.1.4
+// VERSION: 0.2.0
 // PURPOSE: Arduino library for AGS02MA TVOC
 //     URL: https://github.com/RobTillaart/AGS02MA
 
@@ -272,7 +272,7 @@ uint32_t AGS02MA::_readSensor()
   }
   return value;
 }
- 
+
 
 bool AGS02MA::_readRegister(uint8_t reg)
 {

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -216,19 +216,23 @@ bool AGS02MA::manualZeroCalibration(uint16_t value)
 }
 
 
-AGS02MA::ZeroCalibrationData AGS02MA::getZeroCalibrationData() {
-  AGS02MA::ZeroCalibrationData zc;
-  if (_readRegister(AGS02MA_CALIBRATION))
+bool AGS02MA::getZeroCalibrationData(AGS02MA::ZeroCalibrationData &data) {
+  if (!_readRegister(AGS02MA_CALIBRATION))
   {
-    _error = AGS02MA_OK;
-    zc.status = _getDataMSB();
-    zc.value = _getDataLSB();
-    if (_CRC8(_buffer, 5) != 0)
-    {
-      _error = AGS02MA_ERROR_CRC;
-    }
+    return false;
   }
-  return zc;
+
+  if (_CRC8(_buffer, 5) != 0)
+  {
+    _error = AGS02MA_ERROR_CRC;
+    return false;
+  }
+
+  _error = AGS02MA_OK;
+  // Don't pollute the struct given to us, until we've handled all error cases.
+  data.status = _getDataMSB();
+  data.value = _getDataLSB();
+  return true;
 }
 
 

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -205,11 +205,6 @@ uint32_t AGS02MA::readUGM3()
 }
 
 
-bool AGS02MA::zeroCalibration()
-{
-  return manualZeroCalibration(0);
-}
-
 
 bool AGS02MA::manualZeroCalibration(uint16_t value)
 {

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -222,6 +222,22 @@ bool AGS02MA::manualZeroCalibration(uint16_t value)
 }
 
 
+AGS02MA::ZeroCalibration AGS02MA::getZeroCalibration() {
+  AGS02MA::ZeroCalibration zc;
+  if (_readRegister(AGS02MA_CALIBRATION))
+  {
+    _error = AGS02MA_OK;
+    zc.status = _dataMSB(_buffer);
+    zc.value = _dataLSB(_buffer);
+    if (_CRC8(_buffer, 5) != 0)
+    {
+      _error = AGS02MA_ERROR_CRC;
+    }
+  }
+  return zc;
+}
+
+
 int AGS02MA::lastError()
 {
   int e = _error;

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -205,25 +205,24 @@ uint32_t AGS02MA::readUGM3()
 }
 
 
-
 bool AGS02MA::manualZeroCalibration(uint16_t value)
 {
   _buffer[0] = 0x00;
   _buffer[1] = 0x0C;
   _buffer[2] = (uint8_t) (value >> 8);
-  _buffer[3] = (uint8_t) value;
+  _buffer[3] = (uint8_t) (value & 0x00FF);
   _buffer[4] = _CRC8(_buffer, 4);
   return _writeRegister(AGS02MA_CALIBRATION);
 }
 
 
-AGS02MA::ZeroCalibration AGS02MA::getZeroCalibration() {
-  AGS02MA::ZeroCalibration zc;
+AGS02MA::ZeroCalibrationData AGS02MA::getZeroCalibrationData() {
+  AGS02MA::ZeroCalibrationData zc;
   if (_readRegister(AGS02MA_CALIBRATION))
   {
     _error = AGS02MA_OK;
-    zc.status = _dataMSB(_buffer);
-    zc.value = _dataLSB(_buffer);
+    zc.status = _getDataMSB();
+    zc.value = _getDataLSB();
     if (_CRC8(_buffer, 5) != 0)
     {
       _error = AGS02MA_ERROR_CRC;
@@ -318,14 +317,14 @@ bool AGS02MA::_writeRegister(uint8_t reg)
   return (_error == 0);
 }
 
-uint16_t AGS02MA::_dataMSB(uint8_t * buf)
+uint16_t AGS02MA::_getDataMSB()
 {
-  return (buf[0] << 8) + buf[1];
+  return (_buffer[0] << 8) + _buffer[1];
 }
 
-uint16_t AGS02MA::_dataLSB(uint8_t * buf)
+uint16_t AGS02MA::_getDataLSB()
 {
-  return (buf[2] << 8) + buf[3];
+  return (_buffer[2] << 8) + _buffer[3];
 }
 
 uint8_t AGS02MA::_CRC8(uint8_t * buf, uint8_t size)

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -1,9 +1,9 @@
 #pragma once
 //
 //    FILE: AGS02MA.h
-//  AUTHOR: Rob Tillaart, Viktor Balint
+//  AUTHOR: Rob Tillaart, Viktor Balint, Beanow
 //    DATE: 2021-08-12
-// VERSION: 0.1.4
+// VERSION: 0.2.0
 // PURPOSE: Arduino library for AGS02MA TVOC
 //     URL: https://github.com/RobTillaart/AGS02MA
 //
@@ -13,7 +13,7 @@
 #include "Wire.h"
 
 
-#define AGS02MA_LIB_VERSION         (F("0.1.4"))
+#define AGS02MA_LIB_VERSION         (F("0.2.0"))
 
 #define AGS02MA_OK                  0
 #define AGS02MA_ERROR               -10

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -58,7 +58,7 @@ public:
   uint32_t getI2CResetSpeed() { return _I2CResetSpeed; };
 
   // to be called after at least 5 minutes in fresh air.
-  bool     zeroCalibration();
+  bool     zeroCalibration() { return manualZeroCalibration(0); };
 
   /**
    * Set the zero calibration value manually.

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -67,8 +67,8 @@ public:
    * For v117: 0-65535 = automatic calibration.
    * For v118: 0 = automatic calibration, 1-65535 manual calibration.
    */
-  bool                manualZeroCalibration(uint16_t value = 0);
-  ZeroCalibrationData getZeroCalibrationData();
+  bool     manualZeroCalibration(uint16_t value = 0);
+  bool     getZeroCalibrationData(ZeroCalibrationData &data);
 
 
   // MODE

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -28,6 +28,11 @@
 class AGS02MA
 {
 public:
+  struct ZeroCalibration {
+    uint16_t status;
+    uint16_t value;
+  };
+
   // address 26 = 0x1A
   explicit AGS02MA(const uint8_t deviceAddress = 26, TwoWire *wire = &Wire);
 
@@ -62,6 +67,7 @@ public:
    * For v118: 0 = automatic calibration, 1-65535 manual calibration.
    */
   bool            manualZeroCalibration(uint16_t value = 0);
+  ZeroCalibration getZeroCalibration();
 
 
   // MODE

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -30,6 +30,13 @@ class AGS02MA
 public:
   struct ZeroCalibrationData
   {
+    /**
+     * Warning, the exact meaning of this status is not fully documented.
+     * It seems like it's a bitmask:
+     * 0000 1100 | 0x0C | 12  | Typical value
+     * 0000 1101 | 0x0D | 13  | Sometimes seen on v117
+     * 0111 1101 | 0x7D | 125 | Seen on v118, after power-off (gives different data than 12!)
+     */
     uint16_t status;
     uint16_t value;
   };

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -55,6 +55,14 @@ public:
   // to be called after at least 5 minutes in fresh air.
   bool     zeroCalibration();
 
+  /**
+   * Set the zero calibration value manually.
+   * To be called after at least 5 minutes in fresh air.
+   * For v117: 0-65535 = automatic calibration.
+   * For v118: 0 = automatic calibration, 1-65535 manual calibration.
+   */
+  bool            manualZeroCalibration(uint16_t value = 0);
+
 
   // MODE
   bool     setPPBMode();

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -99,6 +99,8 @@ private:
   uint8_t  _status        = 0;
   uint8_t  _buffer[5];
 
+  uint16_t _dataMSB(uint8_t * buf);
+  uint16_t _dataLSB(uint8_t * buf);
   uint8_t  _CRC8(uint8_t * buf, uint8_t size);
   uint8_t  _bin2bcd(uint8_t val);
 

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -28,7 +28,8 @@
 class AGS02MA
 {
 public:
-  struct ZeroCalibration {
+  struct ZeroCalibrationData
+  {
     uint16_t status;
     uint16_t value;
   };
@@ -66,8 +67,8 @@ public:
    * For v117: 0-65535 = automatic calibration.
    * For v118: 0 = automatic calibration, 1-65535 manual calibration.
    */
-  bool            manualZeroCalibration(uint16_t value = 0);
-  ZeroCalibration getZeroCalibration();
+  bool                manualZeroCalibration(uint16_t value = 0);
+  ZeroCalibrationData getZeroCalibrationData();
 
 
   // MODE
@@ -113,8 +114,8 @@ private:
   uint8_t  _status        = 0;
   uint8_t  _buffer[5];
 
-  uint16_t _dataMSB(uint8_t * buf);
-  uint16_t _dataLSB(uint8_t * buf);
+  uint16_t _getDataMSB();
+  uint16_t _getDataLSB();
   uint8_t  _CRC8(uint8_t * buf, uint8_t size);
   uint8_t  _bin2bcd(uint8_t val);
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,10 @@ Typical value should be between 0.01 .. 999.99
 
 - **bool zeroCalibration()** to be called after at least 5 minutes in fresh air.
 See example sketch.
-- **bool manualZeroCalibration(uint16_t value)** for v118 sensors, set the zero calibration value manually.
-0 = automatic calibration, 1-65535 manual calibration.
-- **ZeroCalibration getZeroCalibration()** returns a data struct with the current zero calibration status and value.
+- **bool manualZeroCalibration(uint16_t value = 0)** Set the zero calibration value manually.
+To be called after at least 5 minutes in fresh air.
+For v117: 0-65535 = automatic calibration.
+For v118: 0 = automatic calibration, 1-65535 manual calibration.
 - **bool getZeroCalibrationData(ZeroCalibrationData &data);** fills a data struct with the current zero calibration status and value.
 Returns true on success.
 - **int lastError()** returns last error.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ See example sketch.
 - **bool manualZeroCalibration(uint16_t value)** for v118 sensors, set the zero calibration value manually.
 0 = automatic calibration, 1-65535 manual calibration.
 - **ZeroCalibration getZeroCalibration()** returns a data struct with the current zero calibration status and value.
+- **bool getZeroCalibrationData(ZeroCalibrationData &data);** fills a data struct with the current zero calibration status and value.
+Returns true on success.
 - **int lastError()** returns last error.
 - **uint8_t lastStatus()** returns status byte from last read.
 Read datasheet or table below for details. A new read is needed to update this.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ Typical value should be between 0.01 .. 999.99
 
 - **bool zeroCalibration()** to be called after at least 5 minutes in fresh air.
 See example sketch.
+- **bool manualZeroCalibration(uint16_t value)** for v118 sensors, set the zero calibration value manually.
+0 = automatic calibration, 1-65535 manual calibration.
+- **ZeroCalibration getZeroCalibration()** returns a data struct with the current zero calibration status and value.
 - **int lastError()** returns last error.
 - **uint8_t lastStatus()** returns status byte from last read.
 Read datasheet or table below for details. A new read is needed to update this.

--- a/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
+++ b/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
@@ -75,11 +75,11 @@ void setup()
   Serial.println();
   Serial.println("About to perform calibration now. Your previous calibration data was:");
 
-  auto zc = AGS.getZeroCalibration();
+  auto initialValue = AGS.getZeroCalibration();
   Serial.print("Status:\t");
-  Serial.println(zc.status);
+  Serial.println(initialValue.status);
   Serial.print("Value:\t");
-  Serial.println(zc.value);
+  Serial.println(initialValue.value);
 
   delay(1000);
 
@@ -91,7 +91,7 @@ void setup()
   Serial.println();
 
   Serial.println("Calibration done, your new calibration data is:");
-  zc = AGS.getZeroCalibration();
+  auto zc = AGS.getZeroCalibration();
   Serial.print("Status:\t");
   Serial.println(zc.status);
   Serial.print("Value:\t");
@@ -99,7 +99,9 @@ void setup()
 
   Serial.println();
   Serial.println("Showing what PPB values look like post calibration.");
-  if (version == 118 || zc.status == 125)
+  // A 125 status is typically shown on v118's after they've been powered off.
+  // Either having this version at all, or seeing this status, we'll display a notice.
+  if (version == 118 || initialValue.status == 125)
   {
     Serial.println("NOTICE: v118 sensors are known to give different results after powering off!");
     Serial.println("You may need to manually set your calibration value every time power was lost.");

--- a/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
+++ b/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
@@ -75,7 +75,7 @@ void setup()
   Serial.println();
   Serial.println("About to perform calibration now. Your previous calibration data was:");
 
-  auto initialValue = AGS.getZeroCalibration();
+  auto initialValue = AGS.getZeroCalibrationData();
   Serial.print("Status:\t");
   Serial.println(initialValue.status);
   Serial.print("Value:\t");
@@ -91,7 +91,7 @@ void setup()
   Serial.println();
 
   Serial.println("Calibration done, your new calibration data is:");
-  auto zc = AGS.getZeroCalibration();
+  auto zc = AGS.getZeroCalibrationData();
   Serial.print("Status:\t");
   Serial.println(zc.status);
   Serial.print("Value:\t");

--- a/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
+++ b/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
@@ -15,7 +15,7 @@
 
 
 uint32_t start, stop;
-u_int8_t version;
+uint8_t version;
 
 AGS02MA AGS(26);
 

--- a/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
+++ b/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
@@ -1,7 +1,7 @@
 //
 //    FILE: AGS02MA_calibrate.ino
-//  AUTHOR: Rob Tillaart
-// VERSION: 0.1.0
+//  AUTHOR: Rob Tillaart, Beanow
+// VERSION: 0.2.0
 // PURPOSE: test application
 //    DATE: 2021-08-12
 //     URL: https://github.com/RobTillaart/AGS02MA
@@ -9,15 +9,23 @@
 
 #include "AGS02MA.h"
 
+// You can decrease/disable warmup when you're certain the chip already warmed up.
+#define WARMUP_MINUTES 6
+#define READ_INTERVAL 3000
+
 
 uint32_t start, stop;
-
+u_int8_t version;
 
 AGS02MA AGS(26);
 
 
 void setup()
 {
+  // ESP devices typically mis the first serial log lines after flashing.
+  // Delay somewhat to include all output.
+  delay(1000);
+
   Serial.begin(115200);
   Serial.println(__FILE__);
 
@@ -25,35 +33,99 @@ void setup()
   Serial.println(AGS02MA_LIB_VERSION);
   Serial.println();
 
+  Serial.print("WARMUP:\t\t");
+  Serial.println(WARMUP_MINUTES);
+  Serial.print("INTERVAL:\t");
+  Serial.println(READ_INTERVAL);
+
   Wire.begin();
 
   bool b = AGS.begin();
-  Serial.print("BEGIN:\t");
+  Serial.print("BEGIN:\t\t");
   Serial.println(b);
 
-  Serial.println("Place the device outside in open air for 6 minutes");
-  Serial.println("Take a drink and relax ;)");
+  Serial.print("VERSION:\t");
+  version = AGS.getSensorVersion();
+  Serial.println(version);
+
+  b = AGS.setPPBMode();
+  uint8_t m = AGS.getMode();
+  Serial.print("MODE:\t\t");
+  Serial.print(b);
+  Serial.print("\t");
+  Serial.println(m);
+
+  Serial.println();
+  Serial.print("Place the device outside in open air for ");
+  Serial.print(WARMUP_MINUTES);
+  Serial.println(" minute(s).");
+  Serial.println("Make sure your device has warmed up sufficiently for the best results.");
+  Serial.println("The PPB values should be stable (may include noise) not constantly decreasing.");
   Serial.println();
 
   start = millis();
-  while(millis() - start < 360000UL)
+  stop = WARMUP_MINUTES * 60000UL;
+  while(millis() - start < stop)
   {
-    delay(15000);
-    Serial.println(millis() - start);
+    Serial.print("[PRE ]\t");
+    printPPB();
+    delay(READ_INTERVAL);
   }
+
+  Serial.println();
+  Serial.println("About to perform calibration now. Your previous calibration data was:");
+
+  auto zc = AGS.getZeroCalibration();
+  Serial.print("Status:\t");
+  Serial.println(zc.status);
+  Serial.print("Value:\t");
+  Serial.println(zc.value);
+
+  delay(1000);
 
   // returns 1 if successful written
   b = AGS.zeroCalibration();
+  Serial.println();
   Serial.print("CALIB:\t");
   Serial.println(b);
+  Serial.println();
 
-  Serial.println("Calibration done");
+  Serial.println("Calibration done, your new calibration data is:");
+  zc = AGS.getZeroCalibration();
+  Serial.print("Status:\t");
+  Serial.println(zc.status);
+  Serial.print("Value:\t");
+  Serial.println(zc.value);
+
+  Serial.println();
+  Serial.println("Showing what PPB values look like post calibration.");
+  if (version == 118 || zc.status == 125)
+  {
+    Serial.println("NOTICE: v118 sensors are known to give different results after powering off!");
+    Serial.println("You may need to manually set your calibration value every time power was lost.");
+  }
+  Serial.println();
 }
 
 
 void loop()
 {
+  Serial.print("[POST]\t");
+  printPPB();
+  delay(READ_INTERVAL);
 }
 
+
+void printPPB()
+{
+  uint32_t value = AGS.readPPB();
+  Serial.print("PPB:\t");
+  Serial.print(value);
+  Serial.print("\t");
+  Serial.print(AGS.lastStatus(), HEX);
+  Serial.print("\t");
+  Serial.print(AGS.lastError(), HEX);
+  Serial.println();
+}
 
 // -- END OF FILE --

--- a/examples/AGS02MA_calibrate_manual/AGS02MA_calibrate_manual.ino
+++ b/examples/AGS02MA_calibrate_manual/AGS02MA_calibrate_manual.ino
@@ -18,8 +18,8 @@
 
 AGS02MA AGS(26);
 
-AGS02MA::ZeroCalibration initialValue;
-u_int8_t version;
+AGS02MA::ZeroCalibrationData initialValue;
+uint8_t version;
 
 
 void setup()
@@ -66,8 +66,8 @@ void setup()
 
     Serial.println();
     Serial.println("Your initial zero calibration is:");
-    initialValue = AGS.getZeroCalibration();
-    printZeroCalibration(initialValue);
+    initialValue = AGS.getZeroCalibrationData();
+    printZeroCalibrationData(initialValue);
     Serial.println();
 
     Serial.println("Showing sample data before changing.");
@@ -82,8 +82,8 @@ void setup()
     b = AGS.manualZeroCalibration(ZC_VALUE);
     Serial.print("CALIB:\t");
     Serial.println(b);
-    auto newValue = AGS.getZeroCalibration();
-    printZeroCalibration(newValue);
+    auto newValue = AGS.getZeroCalibrationData();
+    printZeroCalibrationData(newValue);
     Serial.println();
 
     Serial.println("Showing sample data.");
@@ -100,8 +100,8 @@ void setup()
     b = AGS.manualZeroCalibration(initialValue.value);
     Serial.print("CALIB:\t");
     Serial.println(b);
-    auto restoredValue = AGS.getZeroCalibration();
-    printZeroCalibration(restoredValue);
+    auto restoredValue = AGS.getZeroCalibrationData();
+    printZeroCalibrationData(restoredValue);
     Serial.println();
 
   }
@@ -114,7 +114,7 @@ void loop()
   printPPB();
 }
 
-void printZeroCalibration(AGS02MA::ZeroCalibration &zc) {
+void printZeroCalibrationData(AGS02MA::ZeroCalibrationData &zc) {
   Serial.print("Status:\t");
   Serial.println(zc.status);
   Serial.print("Value:\t");

--- a/examples/AGS02MA_calibrate_manual/AGS02MA_calibrate_manual.ino
+++ b/examples/AGS02MA_calibrate_manual/AGS02MA_calibrate_manual.ino
@@ -87,6 +87,8 @@ void setup()
     Serial.println();
 
     Serial.println("Showing sample data.");
+    Serial.println("NOTICE: v118 sensors are known to give different results after powering off!");
+    Serial.println("You may need to manually set your calibration value every time power was lost.");
     for (size_t i = 0; i < READS; i++)
     {
       delay(INTERVAL);

--- a/examples/AGS02MA_calibrate_manual/AGS02MA_calibrate_manual.ino
+++ b/examples/AGS02MA_calibrate_manual/AGS02MA_calibrate_manual.ino
@@ -1,0 +1,134 @@
+//
+//    FILE: AGS02MA_calibrate_manual.ino
+//  AUTHOR: Rob Tillaart, Beanow
+// VERSION: 0.2.0
+// PURPOSE: test application
+//    DATE: 2022-04-22
+//     URL: https://github.com/RobTillaart/AGS02MA
+//
+
+#include "AGS02MA.h"
+
+// The zero calibration value we'll (temporarily) set in the example.
+#define ZC_VALUE 700
+
+#define READS 10
+#define INTERVAL 3000
+
+
+AGS02MA AGS(26);
+
+AGS02MA::ZeroCalibration initialValue;
+u_int8_t version;
+
+
+void setup()
+{
+  // ESP devices typically mis the first serial log lines after flashing.
+  // Delay somewhat to include all output.
+  delay(1000);
+
+  Serial.begin(115200);
+  Serial.println(__FILE__);
+
+  Serial.print("AGS02MA_LIB_VERSION: ");
+  Serial.println(AGS02MA_LIB_VERSION);
+  Serial.println();
+
+  Serial.print("READS:\t\t");
+  Serial.println(READS);
+  Serial.print("INTERVAL:\t");
+  Serial.println(INTERVAL);
+
+  Wire.begin();
+
+  bool b = AGS.begin();
+  Serial.print("BEGIN:\t\t");
+  Serial.println(b);
+
+  Serial.print("VERSION:\t");
+  version = AGS.getSensorVersion();
+  Serial.println(version);
+
+  if (version != 118)
+  {
+    Serial.println();
+    Serial.println("Only v118 sensors support manual zero calibration. For other versions, you can use the 'AGS02MA_calibrate' example instead.");
+  }
+  else
+  {
+    b = AGS.setPPBMode();
+    uint8_t m = AGS.getMode();
+    Serial.print("MODE:\t\t");
+    Serial.print(b);
+    Serial.print("\t");
+    Serial.println(m);
+
+    Serial.println();
+    Serial.println("Your initial zero calibration is:");
+    initialValue = AGS.getZeroCalibration();
+    printZeroCalibration(initialValue);
+    Serial.println();
+
+    Serial.println("Showing sample data before changing.");
+    for (size_t i = 0; i < READS; i++)
+    {
+      delay(INTERVAL);
+      printPPB();
+    }
+
+    Serial.println();
+    Serial.println("Manually setting zero calibration:");
+    b = AGS.manualZeroCalibration(ZC_VALUE);
+    Serial.print("CALIB:\t");
+    Serial.println(b);
+    auto newValue = AGS.getZeroCalibration();
+    printZeroCalibration(newValue);
+    Serial.println();
+
+    Serial.println("Showing sample data.");
+    for (size_t i = 0; i < READS; i++)
+    {
+      delay(INTERVAL);
+      printPPB();
+    }
+
+    Serial.println();
+    Serial.println("Restoring initial zero calibration:");
+    b = AGS.manualZeroCalibration(initialValue.value);
+    Serial.print("CALIB:\t");
+    Serial.println(b);
+    auto restoredValue = AGS.getZeroCalibration();
+    printZeroCalibration(restoredValue);
+    Serial.println();
+
+  }
+
+}
+
+void loop()
+{
+  delay(INTERVAL);
+  printPPB();
+}
+
+void printZeroCalibration(AGS02MA::ZeroCalibration &zc) {
+  Serial.print("Status:\t");
+  Serial.println(zc.status);
+  Serial.print("Value:\t");
+  Serial.println(zc.value);
+}
+
+void printPPB()
+{
+  uint32_t value = AGS.readPPB();
+  Serial.print("PPB:\t");
+  Serial.print(value);
+  Serial.print("\t");
+  Serial.print(AGS.lastStatus(), HEX);
+  Serial.print("\t");
+  Serial.print(AGS.lastError(), HEX);
+  Serial.println();
+}
+
+// -- END OF FILE --

--- a/library.json
+++ b/library.json
@@ -11,6 +11,9 @@
       "name": "Rob Tillaart",
       "email": "Rob.Tillaart@gmail.com",
       "maintainer": true
+    },
+    {
+      "name": "Beanow"
     }
   ],
   "repository":
@@ -18,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/AGS02MA.git"
   },
-  "version": "0.1.4",
+  "version": "0.2.0",
   "license": "MIT",
   "frameworks": "arduino",
   "platforms": "*",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AGS02MA
-version=0.1.4
+version=0.2.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino library for AGS02MA - TVOC sensor


### PR DESCRIPTION
Fixes #13
Closes #14 (supersedes it)

Some choices I would like to get your thoughts on @RobTillaart:

- The `AGS02MA::ZeroCalibration` struct. I think is useful because it's fairly common to need both values, and it would avoid having to read the register twice, at the cost of 2 extra bytes allocated when you don't need both.
But it's a bit different from existing functions. Like `getSensorVersion` and `getSensorDate`, could have been one struct too.
- I've updated the existing example sketch, and added one for manual zero calibration. They are much more verbose than before, including a bunch of hints and PPB output. And I wonder... is it too verbose? Do all the `Serial.print` pollute the actual example code? Or is this a good idea because it provides more utility for calibrating that way? :thinking:

<details><summary>Example output of the updated <code>examples/AGS02MA_calibrate</code>:</summary>

```
/home/beanow/Arduino/libraries/AGS02MA/examples/AGS02MA_calibrate/AGS02MA_calibrate.ino
AGS02MA_LIB_VERSION: 0.2.0

WARMUP:		1
INTERVAL:	3000
BEGIN:		1
VERSION:	118
MODE:		1	0

Place the device outside in open air for 1 minute(s).
Make sure your device has warmed up sufficiently for the best results.
The PPB values should be stable (may include noise) not constantly decreasing.

[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	2	0	0
[PRE ]	PPB:	2	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0
[PRE ]	PPB:	3	0	0

About to perform calibration now. Your previous calibration data was:
Status:	12
Value:	1738

CALIB:	1

Calibration done, your new calibration data is:
Status:	12
Value:	1762

Showing what PPB values look like post calibration.
NOTICE: v118 sensors are known to give different results after powering off!
You may need to manually set your calibration value every time power was lost.

[POST]	PPB:	3	0	0
[POST]	PPB:	5	0	0
[POST]	PPB:	5	0	0
[POST]	PPB:	5	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
[POST]	PPB:	6	0	0
```

</details>

<details><summary>Example output of the new <code>examples/AGS02MA_calibrate_manual</code>:</summary>

```
/home/beanow/Arduino/libraries/AGS02MA/examples/AGS02MA_calibrate_manual/AGS02MA_calibrate_manual.ino
AGS02MA_LIB_VERSION: 0.2.0

READS:		10
INTERVAL:	3000
BEGIN:		1
VERSION:	118
MODE:		1	0

Your initial zero calibration is:
Status:	12
Value:	1762
NOTICE: v118 sensors are known to give different results after powering off!
You may need to manually set your calibration value every time power was lost.

Showing sample data before changing.
PPB:	7	0	0
PPB:	7	0	0
PPB:	8	0	0
PPB:	16	0	0
PPB:	8	0	0
PPB:	8	0	0
PPB:	8	0	0
PPB:	8	0	0
PPB:	8	0	0
PPB:	8	0	0

Manually setting zero calibration:
CALIB:	1
Status:	12
Value:	700

Showing sample data.
PPB:	0	0	0
PPB:	0	0	0
PPB:	0	0	0
PPB:	0	0	0
PPB:	0	0	0
PPB:	0	0	0
PPB:	0	0	0
PPB:	0	0	0
PPB:	0	0	0
PPB:	0	0	0

Restoring initial zero calibration:
CALIB:	1
Status:	12
Value:	1762

PPB:	4	0	0
PPB:	4	0	0
PPB:	4	0	0
PPB:	4	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	4	0	0
PPB:	4	0	0
PPB:	4	0	0
PPB:	4	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
PPB:	5	0	0
```

</details>