### PR TITLE
Register dumping feature

### DIFF
--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -2,7 +2,7 @@
 //    FILE: AGS02MA.cpp
 //  AUTHOR: Rob Tillaart, Viktor Balint, Beanow
 //    DATE: 2021-08-12
-// VERSION: 0.2.0
+// VERSION: 0.3.0
 // PURPOSE: Arduino library for AGS02MA TVOC
 //     URL: https://github.com/RobTillaart/AGS02MA
 

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -224,6 +224,24 @@ int AGS02MA::lastError()
 }
 
 
+int AGS02MA::readRegister(uint8_t address, AGS02MA::Register &reg) {
+  if (_readRegister(address))
+  {
+    _error = AGS02MA_OK;
+    reg.data[0] = _buffer[0];
+    reg.data[1] = _buffer[1];
+    reg.data[2] = _buffer[2];
+    reg.data[3] = _buffer[3];
+    reg.crc = _buffer[4];
+    if (_CRC8(_buffer, 5) != 0)
+    {
+      _error = AGS02MA_ERROR_CRC;
+    }
+  }
+  return _error;
+}
+
+
 /////////////////////////////////////////////////////////
 //
 // PRIVATE

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -249,12 +249,6 @@ bool AGS02MA::readRegister(uint8_t address, AGS02MA::RegisterData &reg) {
     return false;
   }
 
-  if (_CRC8(_buffer, 5) != 0)
-  {
-    _error = AGS02MA_ERROR_CRC;
-    return false;
-  }
-
   _error = AGS02MA_OK;
   // Don't pollute the struct given to us, until we've handled all error cases.
   reg.data[0] = _buffer[0];
@@ -262,6 +256,7 @@ bool AGS02MA::readRegister(uint8_t address, AGS02MA::RegisterData &reg) {
   reg.data[2] = _buffer[2];
   reg.data[3] = _buffer[3];
   reg.crc = _buffer[4];
+  reg.crcValid = _CRC8(_buffer, 5) == 0;
   return true;
 }
 

--- a/AGS02MA.cpp
+++ b/AGS02MA.cpp
@@ -223,24 +223,27 @@ int AGS02MA::lastError()
   return e;
 }
 
-
-int AGS02MA::readRegister(uint8_t address, AGS02MA::Register &reg) {
-  if (_readRegister(address))
+bool AGS02MA::readRegister(uint8_t address, AGS02MA::RegisterData &reg) {
+  if (!_readRegister(address))
   {
-    _error = AGS02MA_OK;
-    reg.data[0] = _buffer[0];
-    reg.data[1] = _buffer[1];
-    reg.data[2] = _buffer[2];
-    reg.data[3] = _buffer[3];
-    reg.crc = _buffer[4];
-    if (_CRC8(_buffer, 5) != 0)
-    {
-      _error = AGS02MA_ERROR_CRC;
-    }
+    return false;
   }
-  return _error;
-}
 
+  if (_CRC8(_buffer, 5) != 0)
+  {
+    _error = AGS02MA_ERROR_CRC;
+    return false;
+  }
+
+  _error = AGS02MA_OK;
+  // Don't pollute the struct given to us, until we've handled all error cases.
+  reg.data[0] = _buffer[0];
+  reg.data[1] = _buffer[1];
+  reg.data[2] = _buffer[2];
+  reg.data[3] = _buffer[3];
+  reg.crc = _buffer[4];
+  return true;
+}
 
 /////////////////////////////////////////////////////////
 //

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -32,6 +32,7 @@ public:
   {
     uint8_t data[4];
     uint8_t crc;
+    bool    crcValid;
   };
 
   struct ZeroCalibrationData

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -13,7 +13,7 @@
 #include "Wire.h"
 
 
-#define AGS02MA_LIB_VERSION         (F("0.1.4"))
+#define AGS02MA_LIB_VERSION         (F("0.3.0-pre"))
 
 #define AGS02MA_OK                  0
 #define AGS02MA_ERROR               -10
@@ -28,6 +28,12 @@
 class AGS02MA
 {
 public:
+  struct Register
+  {
+    uint8_t data[4];
+    uint8_t crc;
+  };
+
   // address 26 = 0x1A
   explicit AGS02MA(const uint8_t deviceAddress = 26, TwoWire *wire = &Wire);
 
@@ -81,6 +87,9 @@ public:
   int      lastError();
   uint8_t  lastStatus() { return _status; };
   uint8_t  dataReady()  { return _status & 0x01; };
+
+  // Register dumping
+  int      readRegister(uint8_t address, Register &reg);
 
 
 private:

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -28,7 +28,7 @@
 class AGS02MA
 {
 public:
-  struct Register
+  struct RegisterData
   {
     uint8_t data[4];
     uint8_t crc;
@@ -88,8 +88,8 @@ public:
   uint8_t  lastStatus() { return _status; };
   uint8_t  dataReady()  { return _status & 0x01; };
 
-  // Register dumping
-  int      readRegister(uint8_t address, Register &reg);
+  // Reading registers
+  bool     readRegister(uint8_t address, RegisterData &reg);
 
 
 private:

--- a/AGS02MA.h
+++ b/AGS02MA.h
@@ -3,7 +3,7 @@
 //    FILE: AGS02MA.h
 //  AUTHOR: Rob Tillaart, Viktor Balint, Beanow
 //    DATE: 2021-08-12
-// VERSION: 0.2.0
+// VERSION: 0.3.0
 // PURPOSE: Arduino library for AGS02MA TVOC
 //     URL: https://github.com/RobTillaart/AGS02MA
 //

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ For v118: 0 = automatic calibration, 1-65535 manual calibration.
 Returns true on success.
 - **bool readRegister(uint8_t address, RegisterData &reg)** fills a data struct with the chip's register data at that address.
 Primarily intended for troubleshooting and analysis of the sensor. Not recommended to build applications on top of this method's raw data.
-Returns true on success.
+Returns true when the struct is filled, false when the data could not be read.
+Note: unlike other public methods, CRC errors don't return false or show up in `lastError()`, instead the CRC result is stored in `RegisterData.crcValid`.
 - **int lastError()** returns last error.
 - **uint8_t lastStatus()** returns status byte from last read.
 Read datasheet or table below for details. A new read is needed to update this.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,10 @@ See example sketch.
 To be called after at least 5 minutes in fresh air.
 For v117: 0-65535 = automatic calibration.
 For v118: 0 = automatic calibration, 1-65535 manual calibration.
-- **bool getZeroCalibrationData(ZeroCalibrationData &data);** fills a data struct with the current zero calibration status and value.
+- **bool getZeroCalibrationData(ZeroCalibrationData &data)** fills a data struct with the current zero calibration status and value.
+Returns true on success.
+- **bool readRegister(uint8_t address, RegisterData &reg)** fills a data struct with the chip's register data at that address.
+Primarily intended for troubleshooting and analysis of the sensor. Not recommended to build applications on top of this method's raw data.
 Returns true on success.
 - **int lastError()** returns last error.
 - **uint8_t lastStatus()** returns status byte from last read.

--- a/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
+++ b/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
@@ -123,9 +123,4 @@ void printRegister(uint8_t address, AGS02MA::RegisterData &reg) {
 }
 
 
-void printSpecific(uint8_t address, AGS02MA::Register &reg) {
-  
-}
-
-
 // -- END OF FILE --

--- a/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
+++ b/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
@@ -1,0 +1,132 @@
+//
+//    FILE: AGS02MA_readRegister.ino
+//  AUTHOR: Rob Tillaart, Beanow
+// VERSION: 0.3.0-pre
+// PURPOSE: test application
+//    DATE: 2022-04-22
+//     URL: https://github.com/RobTillaart/AGS02MA
+//
+
+
+#include "AGS02MA.h"
+
+
+const uint8_t addresses[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 0x11, 0x20, 0x21};
+
+
+AGS02MA::Register reg;
+AGS02MA AGS(26);
+
+
+void setup()
+{
+  // ESP devices typically mis the first serial log lines after flashing.
+  // Delay somewhat to include all output.
+  delay(1000);
+
+  Serial.begin(115200);
+  Serial.println(__FILE__);
+
+  Wire.begin();
+
+  Serial.print("AGS02MA_LIB_VERSION: ");
+  Serial.println(AGS02MA_LIB_VERSION);
+  Serial.println();
+
+  bool b = AGS.begin();
+  Serial.print("BEGIN:\t");
+  Serial.println(b);
+}
+
+
+void loop()
+{
+  delay(3000);
+  for (auto address : addresses)
+  {
+    int status = AGS.readRegister(address, reg);
+
+    Serial.print("REG[0x");
+    Serial.print(address, HEX);
+    Serial.print("]");
+
+    if(status == AGS02MA_OK)
+    {
+      printRegister(address, reg);
+    }
+    else
+    {
+      Serial.print("\tError:\t");
+      Serial.println(status);
+    }
+    delay(50);
+  }
+  Serial.println();
+}
+
+
+void printRegister(uint8_t address, AGS02MA::Register &reg) {
+  // Raw bytes first for any register.
+  for (auto b : reg.data)
+  {
+    Serial.print("\t");
+    Serial.print(b);
+  }
+
+  Serial.print("\tC: ");
+  Serial.print(reg.crc);
+  Serial.print("\t");
+
+  // Specific interpretations
+  switch (address)
+  {
+  case 0x00:
+    Serial.print("\tSensor data:\t");
+    Serial.print(reg.data[0]);
+    Serial.print("\t");
+    Serial.print(
+      (reg.data[1] << 16) +
+      (reg.data[2] << 8) +
+      reg.data[3]
+    );
+    break;
+  
+  case 0x01:
+  case 0x02:
+  case 0x03:
+  case 0x04:
+    Serial.print("\tCalibration:\t");
+    Serial.print(
+      (reg.data[0] << 8) +
+      reg.data[1]
+    );
+    Serial.print("\t");
+    Serial.print(
+      (reg.data[2] << 8) +
+      reg.data[3]
+    );
+    break;
+  
+  case 0x11:
+    Serial.print("\tVersion:\t");
+    Serial.print(reg.data[3]);
+    break;
+  
+  case 0x21:
+    Serial.print("\tI2C address:\t0x");
+    Serial.print(reg.data[0], HEX);
+    break;
+  
+  default:
+    break;
+  }
+  Serial.println();
+}
+
+
+void printSpecific(uint8_t address, AGS02MA::Register &reg) {
+  
+}
+
+
+// -- END OF FILE --

--- a/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
+++ b/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
@@ -72,9 +72,9 @@ void printRegister(uint8_t address, AGS02MA::RegisterData &reg) {
     Serial.print(b);
   }
 
-  Serial.print("\tC: ");
+  Serial.print("\tCRC: ");
+  Serial.print(reg.crcValid ? "OK  " : "ERR ");
   Serial.print(reg.crc);
-  Serial.print("\t");
 
   // Specific interpretations
   switch (address)

--- a/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
+++ b/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
@@ -14,7 +14,7 @@
 const uint8_t addresses[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 0x11, 0x20, 0x21};
 
 
-AGS02MA::Register reg;
+AGS02MA::RegisterData reg;
 AGS02MA AGS(26);
 
 
@@ -44,20 +44,19 @@ void loop()
   delay(3000);
   for (auto address : addresses)
   {
-    int status = AGS.readRegister(address, reg);
-
+    bool b = AGS.readRegister(address, reg);
     Serial.print("REG[0x");
     Serial.print(address, HEX);
     Serial.print("]");
 
-    if(status == AGS02MA_OK)
+    if(b)
     {
       printRegister(address, reg);
     }
     else
     {
       Serial.print("\tError:\t");
-      Serial.println(status);
+      Serial.println(AGS.lastError());
     }
     delay(50);
   }
@@ -65,7 +64,7 @@ void loop()
 }
 
 
-void printRegister(uint8_t address, AGS02MA::Register &reg) {
+void printRegister(uint8_t address, AGS02MA::RegisterData &reg) {
   // Raw bytes first for any register.
   for (auto b : reg.data)
   {

--- a/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
+++ b/examples/AGS02MA_readRegister/AGS02MA_readRegister.ino
@@ -1,7 +1,7 @@
 //
 //    FILE: AGS02MA_readRegister.ino
 //  AUTHOR: Rob Tillaart, Beanow
-// VERSION: 0.3.0-pre
+// VERSION: 0.3.0
 // PURPOSE: test application
 //    DATE: 2022-04-22
 //     URL: https://github.com/RobTillaart/AGS02MA

--- a/library.json
+++ b/library.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/AGS02MA.git"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "frameworks": "arduino",
   "platforms": "*",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AGS02MA
-version=0.2.0
+version=0.3.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino library for AGS02MA - TVOC sensor


### PR DESCRIPTION
In a somewhat similar way to the proposed calibration feature, here's an idea for a minimal register dumping function.
If you're not using this, it only adds a small amount of code to the actual library, offloading all speculative interpretation of register data to the example sketch.

Sample output:
```
REG[0x0]	0	0	0	166	C: 141		Sensor data:	0	166
REG[0x1]	0	125	6	252	C: 96		Calibration:	125	1788
REG[0x2]	0	100	2	126	C: 75		Calibration:	100	638
REG[0x3]	3	232	0	227	C: 213		Calibration:	1000	227
REG[0x4]	39	16	0	81	C: 222		Calibration:	10000	81
REG[0x5]	238	72	35	40	C: 205	
REG[0x6]	26	0	0	18	C: 213	
REG[0x7]	2	92	132	29	C: 82	
REG[0x8]	211	118	0	28	C: 214	
REG[0x11]	21	2	3	118	C: 133		Version:	118
REG[0x20]	0	2	92	211	C: 95	
REG[0x21]	26	229	26	229	C: 113		I2C address:	0x1A
```